### PR TITLE
Fix running MultiMC on Linux

### DIFF
--- a/src/launcher.py
+++ b/src/launcher.py
@@ -215,7 +215,8 @@ def launchMinecraft(ipaddr, port, version, mppass):
             exe = "MultiMC"
         #end if
 
-        subprocess.run(os.path.abspath(os.path.join(Config.multiMcPath(), exe)) + " -l \"" + version + "\"", shell=False, check=False)
+        # subprocess.run(os.path.abspath(os.path.join(Config.multiMcPath(), exe)) + " -l \"" + version + "\"", shell=False, check=False)
+        subprocess.run([os.path.abspath(os.path.join(Config.multiMcPath(), exe)), "-l", version], shell=False, check=False)
         sys.exit()
     except FileNotFoundError:
         errorDialog("Unable to find configuration file,\n\nprogram may not have been installed properly.")


### PR DESCRIPTION
The launcher will not run MultiMC on Linux and possibly on macOS too, showing `Unable to find configuration file, program may not have been installed properly`.
The reason behind this is that the launcher will run an executable named `MultiMC -l version`, and not the `MultiMC` executable with the arguments `-l version`.